### PR TITLE
Add "main" field to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
   "files": [
     "index.json"
   ],
+  "main": "index.json",
   "scripts": {
     "build": "node build.js"
   }


### PR DESCRIPTION
Hello!

[The default value for the `main` field in `package.json` is `index.js`](https://docs.npmjs.com/cli/v8/configuring-npm/package-json#main). The `vite` build tool takes this literally and cannot find `index.json` in this package, and thus cannot build any package depending on this one. See the error in the following discussion for more details.

https://github.com/vitejs/vite/discussions/3892

This PR adds the `main` field to `package.json`, resolving the issue. I made a similar PR in the `spdx-licence-ids` package  as well.

https://github.com/jslicense/spdx-license-ids/pull/29