### PR TITLE
fix: better license for code

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "contributors": [
     "Kyle E. Mitchell <kyle@kemitchell.com> (https://kemitchell.com/)"
   ],
-  "license": "CC-BY-3.0",
+  "license": "CC-BY-SA-3.0",
   "repository": "kemitchell/spdx-exceptions.json",
   "files": [
     "index.json",


### PR DESCRIPTION
CC-BY-3.0 is typically used for graphics, images etc according to our legal department. This might be more appropriate for code.